### PR TITLE
Feature/navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { AiOutlineMenu } from 'react-icons/ai'
 import { TooltipComponent } from '@syncfusion/ej2-react-popups'
 import { FiShoppingCart } from 'react-icons/fi'
@@ -44,8 +44,26 @@ NavBtn.defaultProps = {
 }
 
 const Navbar = () => {
-	const { setActiveMenu, isClicked, handleClick } =
+	const { setActiveMenu, isClicked, handleClick, screenSize, setScreenSize } =
 		useStateContext() as StoreContextInterface
+
+	useEffect(() => {
+		const handleResize = () => setScreenSize(window.innerWidth)
+
+		window.addEventListener('resize', handleResize)
+
+		handleResize()
+
+		return () => window.removeEventListener('resize', handleResize)
+	}, [])
+
+	useEffect(() => {
+		if (screenSize <= 900) {
+			setActiveMenu(false)
+		} else {
+			setActiveMenu(true)
+		}
+	}, [screenSize])
 
 	return (
 		<div className="flex justify-between p-2 md:mx-6 relative">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,55 @@
 import React from 'react'
+import { AiOutlineMenu } from 'react-icons/ai'
+import { TooltipComponent } from '@syncfusion/ej2-react-popups'
 
-const Navbar = () => <div>Navbar</div>
+import {
+	StoreContextInterface,
+	useStateContext,
+} from '../contexts/ContextProvider'
+
+interface NavBtnProps {
+	title: string
+	color: string
+	dotColor?: string
+	customFn: () => void
+	icon: React.ReactNode
+}
+
+const NavBtn = ({ title, customFn, icon, color, dotColor }: NavBtnProps) => (
+	<TooltipComponent content={title} position="BottomCenter">
+		<button
+			type="button"
+			onClick={customFn}
+			style={{ color }}
+			className="relative text-xl rounded-full p-3 hover:bg-light-gray"
+		>
+			<span
+				style={{ background: dotColor }}
+				className="absolute inline-flex rounded-full h-2 w-2 right-2 top-2"
+			>
+				{icon}
+			</span>
+		</button>
+	</TooltipComponent>
+)
+
+NavBtn.defaultProps = {
+	dotColor: '',
+}
+
+const Navbar = () => {
+	const { setActiveMenu } = useStateContext() as StoreContextInterface
+
+	return (
+		<div className="flex justify-items-between p-2 md:mx-6 relative">
+			<NavBtn
+				title="Menu"
+				customFn={() => setActiveMenu((prevActiveMenu) => !prevActiveMenu)}
+				color="blue"
+				icon={<AiOutlineMenu />}
+			/>
+		</div>
+	)
+}
 
 export default Navbar

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { AiOutlineMenu } from 'react-icons/ai'
 import { TooltipComponent } from '@syncfusion/ej2-react-popups'
+import { FiShoppingCart } from 'react-icons/fi'
+import { BsChatLeft } from 'react-icons/bs'
+import { RiNotification3Line } from 'react-icons/ri'
+import { MdKeyboardArrowDown } from 'react-icons/md'
+import avatar from '../data/avatar.jpg'
 
 import {
 	StoreContextInterface,
@@ -40,14 +45,61 @@ NavBtn.defaultProps = {
 const Navbar = () => {
 	const { setActiveMenu } = useStateContext() as StoreContextInterface
 
+	const handleClick = (e: string) => {
+		// eslint-disable-next-line no-console
+		console.log(e)
+	}
+
 	return (
-		<div className="flex justify-items-between p-2 md:mx-6 relative">
+		<div className="flex justify-between p-2 md:mx-6 relative">
 			<NavBtn
 				title="Menu"
 				customFn={() => setActiveMenu((prevActiveMenu) => !prevActiveMenu)}
 				color="blue"
 				icon={<AiOutlineMenu />}
 			/>
+			<div className="flex">
+				<NavBtn
+					title="Cart"
+					customFn={() => handleClick('cart')}
+					color="blue"
+					icon={<FiShoppingCart />}
+				/>
+				<NavBtn
+					title="Chat"
+					customFn={() => handleClick('chat')}
+					dotColor="#03C9D7"
+					color="blue"
+					icon={<BsChatLeft />}
+				/>
+				<NavBtn
+					title="Notifications"
+					customFn={() => handleClick('notification')}
+					dotColor="#03C9D7"
+					color="blue"
+					icon={<RiNotification3Line />}
+				/>
+				<TooltipComponent content="Profile" position="BottomCenter">
+					<div
+						role="presentation"
+						className="flex item-center gap-2 cursor-pointer p-1 hover:bg-light-gray rounded-lg"
+						onClick={() => handleClick('userProfile')}
+					>
+						<img
+							className="rounded-full w-8 h-8"
+							src={avatar}
+							alt="user avatar"
+						/>
+						<p>
+							<span className="text-gray-400 text-14">Hi, </span>{' '}
+							<span className="text-gray-400 text-bold ml-1 text-14">
+								Michel
+							</span>
+						</p>
+						<MdKeyboardArrowDown className="text-gray-400 text-14" />
+					</div>
+				</TooltipComponent>
+			</div>
 		</div>
 	)
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,6 +11,7 @@ import {
 	StoreContextInterface,
 	useStateContext,
 } from '../contexts/ContextProvider'
+import { Cart, Chat, Notification, UserProfile } from '.'
 
 interface NavBtnProps {
 	title: string
@@ -24,7 +25,7 @@ const NavBtn = ({ title, customFn, icon, color, dotColor }: NavBtnProps) => (
 	<TooltipComponent content={title} position="BottomCenter">
 		<button
 			type="button"
-			onClick={customFn}
+			onClick={() => customFn()}
 			style={{ color }}
 			className="relative text-xl rounded-full p-3 hover:bg-light-gray"
 		>
@@ -43,12 +44,8 @@ NavBtn.defaultProps = {
 }
 
 const Navbar = () => {
-	const { setActiveMenu } = useStateContext() as StoreContextInterface
-
-	const handleClick = (e: string) => {
-		// eslint-disable-next-line no-console
-		console.log(e)
-	}
+	const { setActiveMenu, isClicked, handleClick } =
+		useStateContext() as StoreContextInterface
 
 	return (
 		<div className="flex justify-between p-2 md:mx-6 relative">
@@ -99,6 +96,10 @@ const Navbar = () => {
 						<MdKeyboardArrowDown className="text-gray-400 text-14" />
 					</div>
 				</TooltipComponent>
+				{isClicked.cart === true && <Cart />}
+				{isClicked.chat === true && <Chat />}
+				{isClicked.notification === true && <Notification />}
+				{isClicked.userProfile === true && <UserProfile />}
 			</div>
 		</div>
 	)

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -32,9 +32,8 @@ const NavBtn = ({ title, customFn, icon, color, dotColor }: NavBtnProps) => (
 			<span
 				style={{ background: dotColor }}
 				className="absolute inline-flex rounded-full h-2 w-2 right-2 top-2"
-			>
-				{icon}
-			</span>
+			/>
+			{icon}
 		</button>
 	</TooltipComponent>
 )

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,8 +11,15 @@ import {
 } from '../contexts/ContextProvider'
 
 const Sidebar = () => {
-	const { activeMenu, setActiveMenu } =
+	const { activeMenu, setActiveMenu, screenSize } =
 		useStateContext() as StoreContextInterface
+
+	const handleCloseSideBar = () => {
+		if (activeMenu && screenSize <= 900) {
+			setActiveMenu(false)
+		}
+	}
+
 	const activeLink =
 		'flex items-center gap-5 pl-4 pt-3 pb-2.5 rounded-lg  text-white  text-md m-2'
 	const normalLink =
@@ -25,7 +32,7 @@ const Sidebar = () => {
 					<div className="flex justify-between items-center">
 						<Link
 							to="/"
-							onClick={() => setActiveMenu(false)}
+							onClick={handleCloseSideBar}
 							className="items-center gap-3 ml-3 mt-4 flex text-xl tracking-tight font-extrabold dark:text-white text-slate-900"
 						>
 							<SiShopware /> <span>Shoppi</span>
@@ -50,7 +57,7 @@ const Sidebar = () => {
 									<NavLink
 										to={`/${link.name}`}
 										key={link.name}
-										onClick={() => {}}
+										onClick={handleCloseSideBar}
 										className={({ isActive }) =>
 											isActive ? activeLink : normalLink
 										}

--- a/src/contexts/ContextProvider.tsx
+++ b/src/contexts/ContextProvider.tsx
@@ -11,6 +11,21 @@ import React, {
 export interface StoreContextInterface {
 	activeMenu: boolean
 	setActiveMenu: Dispatch<SetStateAction<boolean>>
+	handleClick: (clicked: string) => void
+	isClicked: {
+		chat: boolean
+		cart: boolean
+		userProfile: boolean
+		notification: boolean
+	}
+	setIsClicked: Dispatch<
+		SetStateAction<{
+			chat: boolean
+			cart: boolean
+			userProfile: boolean
+			notification: boolean
+		}>
+	>
 }
 
 const initialState = {
@@ -24,10 +39,15 @@ const StateContext = createContext<StoreContextInterface | null>(null)
 
 export const ContextProvider = ({ children }: PropsWithChildren) => {
 	const [activeMenu, setActiveMenu] = useState(true)
+	const [isClicked, setIsClicked] = useState(initialState)
+
+	const handleClick = (clicked: string) => {
+		setIsClicked({ ...initialState, [clicked]: true })
+	}
 
 	const globalContextValue = useMemo(
-		() => ({ activeMenu, setActiveMenu, initialState }),
-		[activeMenu, setActiveMenu]
+		() => ({ activeMenu, setActiveMenu, isClicked, setIsClicked, handleClick }),
+		[activeMenu, setActiveMenu, isClicked, setIsClicked]
 	)
 
 	return (

--- a/src/contexts/ContextProvider.tsx
+++ b/src/contexts/ContextProvider.tsx
@@ -26,6 +26,8 @@ export interface StoreContextInterface {
 			notification: boolean
 		}>
 	>
+	screenSize: number
+	setScreenSize: Dispatch<SetStateAction<number>>
 }
 
 const initialState = {
@@ -40,14 +42,30 @@ const StateContext = createContext<StoreContextInterface | null>(null)
 export const ContextProvider = ({ children }: PropsWithChildren) => {
 	const [activeMenu, setActiveMenu] = useState(true)
 	const [isClicked, setIsClicked] = useState(initialState)
+	const [screenSize, setScreenSize] = useState(0)
 
 	const handleClick = (clicked: string) => {
 		setIsClicked({ ...initialState, [clicked]: true })
 	}
 
 	const globalContextValue = useMemo(
-		() => ({ activeMenu, setActiveMenu, isClicked, setIsClicked, handleClick }),
-		[activeMenu, setActiveMenu, isClicked, setIsClicked]
+		() => ({
+			activeMenu,
+			setActiveMenu,
+			isClicked,
+			setIsClicked,
+			handleClick,
+			screenSize,
+			setScreenSize,
+		}),
+		[
+			activeMenu,
+			setActiveMenu,
+			isClicked,
+			setIsClicked,
+			screenSize,
+			setScreenSize,
+		]
 	)
 
 	return (


### PR DESCRIPTION
[add: navbar to collapse and expand sidebar](https://github.com/MarkRasavong/syncfusionDash/commit/ca31184066fd0e63ea7924a2493ee2b3b3ddaaff)

⭐ resusable NavBtn component
 
[add: style navbar buttons and profile dropdown](https://github.com/MarkRasavong/syncfusionDash/commit/176eae648bd674668401312eb50c15d5e4686ec8)


⭐ adds and styles new navbar icons or menu buttons
 
[add: render component on selected navbar btn](https://github.com/MarkRasavong/syncfusionDash/commit/755fe88e0811757858b0f901a923510e89d5a1c4)


⭐ when user interacts with the navbar icons such as notifcations, user avatar, cart, and chat. It will 'redirect' the user to the correct component.
 
[add: mobile sidebar closing at home and route change](https://github.com/MarkRasavong/syncfusionDash/commit/637afa0dad13e21d2b75b71978d2bac4596170bc)

⭐ mobile devices under 900px of width will have a closed sidebar at first inital visit to home and when using the sidebar to navigate to another route.

[fix: icon hamburger size](https://github.com/MarkRasavong/syncfusionDash/commit/c2dfc0b296f5c557f1ba07acb0d4a3c39cffb839)

⭐ resize hamburger icon size














