### PR TITLE
Feature/orders page data tables

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,17 @@
 import React from 'react'
 
-const Header = () => <div>Header</div>
+interface HeaderProps {
+	category: string
+	title: string
+}
+
+const Header = ({ category, title }: HeaderProps) => (
+	<div className="mb-10">
+		<p className="text-gray-400">{category}</p>
+		<p className="text-3xl font-extrabold tracking-tight text-slate-900">
+			{title}
+		</p>
+	</div>
+)
 
 export default Header

--- a/src/data/dummy.tsx
+++ b/src/data/dummy.tsx
@@ -32,6 +32,7 @@ import { TiTick } from 'react-icons/ti'
 import { GiLouvrePyramid } from 'react-icons/gi'
 import { GrLocation } from 'react-icons/gr'
 import { AxisModel } from '@syncfusion/ej2-react-charts'
+import { ContextMenuItem } from '@syncfusion/ej2-react-grids'
 import avatar from './avatar.jpg'
 import avatar2 from './avatar2.jpg'
 import avatar3 from './avatar3.png'
@@ -3033,7 +3034,7 @@ export const pieChartData = [
 	{ x: 'Insurance', y: 16, text: '16%' },
 ]
 
-export const contextMenuItems = [
+export const contextMenuItems: ContextMenuItem[] = [
 	'AutoFit',
 	'AutoFitAll',
 	'SortAscending',

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,9 +1,59 @@
 import React from 'react'
+import {
+	GridComponent,
+	ColumnsDirective,
+	ColumnDirective,
+	Resize,
+	Sort,
+	ContextMenu,
+	Filter,
+	Page,
+	ExcelExport,
+	PdfExport,
+	Edit,
+	Inject,
+	TextAlign,
+} from '@syncfusion/ej2-react-grids'
+
+import { ordersData, contextMenuItems, ordersGrid } from '../data/dummy'
 import { Header } from '../components'
 
 const Orders = () => (
-	<div>
+	<div className="m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl">
 		<Header title="Orders" category="Page" />
+		<GridComponent
+			id="gridcomp"
+			dataSource={ordersData}
+			allowPaging
+			allowSorting
+		>
+			<ColumnsDirective>
+				{ordersGrid.map((ele, idx) => (
+					<ColumnDirective
+						key={`ColDirect_${idx + Math.random()}`}
+						headerText={ele.headerText}
+						template={ele.template}
+						textAlign={(ele.textAlign as TextAlign) || undefined}
+						width={ele.width}
+						field={ele.field}
+						editType={ele.editType}
+						format={ele.format}
+					/>
+				))}
+			</ColumnsDirective>
+			<Inject
+				services={[
+					Resize,
+					Sort,
+					ContextMenu,
+					Filter,
+					Page,
+					ExcelExport,
+					Edit,
+					PdfExport,
+				]}
+			/>
+		</GridComponent>
 	</div>
 )
 

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -24,6 +24,7 @@ const Orders = () => (
 		<GridComponent
 			id="gridcomp"
 			dataSource={ordersData}
+			contextMenuItems={contextMenuItems}
 			allowPaging
 			allowSorting
 		>

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
+import { Header } from '../components'
 
-const Orders = () => <div>Orders</div>
+const Orders = () => (
+	<div>
+		<Header title="Orders" category="Page" />
+	</div>
+)
 
 export default Orders


### PR DESCRIPTION
🌟 Orders Page : Data Table

[add: Header component and render to Orders page](https://github.com/MarkRasavong/syncfusionDash/commit/82ff9d745c85139434b773a1ef40b2053b40d0e6)
⚙ New Header Component
[add: add and display orders table with full functionality](https://github.com/MarkRasavong/syncfusionDash/commit/d0ec614fbd779585b417569e19614adc887055f1)
⚙ User is able to interact with table (sort, pagination, next page, and etc)
[fix: give type to contextMenuItems dummy data](https://github.com/MarkRasavong/syncfusionDash/commit/582285f1f72f5c526400c9c66e766a8fcb887379)
⚙ Fix TS error for contextMenuItem props in GridComponent @ orders page